### PR TITLE
Adds bosh cleanup option to deployment resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ the UUID returned by the targeted director.
 * `releases`: *Required.* An array of globs that should point to where the
   releases used in the deployment can be found.
 
+* `cleanup`: *Optional* An boolean that specifies if a bosh cleanup should be
+  run before deployment. Defaults to false.
+
 * `target_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool

--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -21,6 +21,10 @@ module BoshDeploymentResource
     def deploy(manifest_path)
       bosh("-d #{manifest_path} deploy")
     end
+    
+    def cleanup
+      bosh("cleanup")
+    end
 
     def director_uuid
       r, w = IO.pipe

--- a/lib/bosh_deployment_resource/out_command.rb
+++ b/lib/bosh_deployment_resource/out_command.rb
@@ -12,6 +12,8 @@ module BoshDeploymentResource
     def run(working_dir, request)
       validate! request
 
+      bosh.cleanup if request.fetch("params")["cleanup"].equal? true
+      
       stemcells = []
       releases = []
 
@@ -66,6 +68,12 @@ module BoshDeploymentResource
         raise "given deployment name '#{deployment_name}' does not match manifest name '#{manifest.name}'"
       end
 
+      case request.fetch("params")["cleanup"]
+      when nil, true, false
+      else
+        raise "given cleanup value must be a boolean"
+      end
+      
       ["manifest", "stemcells", "releases"].each do |field|
         request.fetch("params").fetch(field) { raise "params must include '#{field}'" }
       end

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -170,6 +170,28 @@ describe "Out Command" do
         command.run(working_dir, request)
       end
     end
+      
+    it "does NOT run a bosh cleanup when the cleanup parameter is NOT passed" do
+      in_dir do |working_dir|
+        add_default_artefacts working_dir
+
+        expect(bosh).not_to receive(:cleanup)
+
+        command.run(working_dir, request)
+      end
+    end
+    
+    it "runs a bosh cleanup when the cleanup parameter is set to true" do
+      request.fetch("params").store("cleanup", true)
+    
+      in_dir do |working_dir|
+        add_default_artefacts working_dir
+
+        expect(bosh).to receive(:cleanup)
+
+        command.run(working_dir, request)
+      end
+    end
   end
 
   context "with invalid inputs" do
@@ -268,6 +290,27 @@ describe "Out Command" do
             }
           })
         end.to raise_error /params must include 'manifest'/
+      end
+    end
+    
+    it "errors if the cleanup paramater is NOT a boolean value" do
+      in_dir do |working_dir|
+        expect do
+          command.run(working_dir, {
+            "source" => {
+              "target" => "http://bosh.example.com",
+              "username" => "bosh-username",
+              "password" => "bosh-password",
+              "deployment" => "bosh-deployment",
+            },
+            "params" => {
+              "manifest" => "deployment.yml",
+              "stemcells" => [],
+              "releases" => [],
+              "cleanup" => 1
+            }
+          })
+        end.to raise_error /given cleanup value must be a boolean/
       end
     end
 


### PR DESCRIPTION
This would be useful in a pipeline that makes bosh deploys often with on-the-fly dev releases. Given how big some of the releases are, a given bosh director machine can run out of disk space relatively quickly.