### PR TITLE
redact diff by default

### DIFF
--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -19,9 +19,9 @@ module BoshDeploymentResource
     end
 
     def deploy(manifest_path)
-      bosh("-d #{manifest_path} deploy")
+      bosh("-d #{manifest_path} deploy --redact-diff")
     end
-    
+
     def cleanup
       bosh("cleanup")
     end


### PR DESCRIPTION
Passwords and SSL keys are shown in BOSH Deploy diff and keep forever in concourse.. We should do this by default fixes #15 