### PR TITLE
Refine error message if release not found in releases list

### DIFF
--- a/lib/bosh_deployment_resource/bosh_manifest.rb
+++ b/lib/bosh_deployment_resource/bosh_manifest.rb
@@ -13,7 +13,7 @@ module BoshDeploymentResource
 
     def use_release(release)
       manifest.fetch("releases").
-        find { |r| r.fetch("name") == release.name }.
+        find(no_release_found(release.name)) { |r| r.fetch("name") == release.name }.
         store("version", release.version)
     end
 
@@ -38,5 +38,9 @@ module BoshDeploymentResource
     private
 
     attr_reader :manifest
+
+    def no_release_found(name)
+        Proc.new { raise "#{name} can not be found in manifest releases" }
+    end
   end
 end

--- a/spec/bosh_manifest_spec.rb
+++ b/spec/bosh_manifest_spec.rb
@@ -96,4 +96,12 @@ describe BoshDeploymentResource::BoshManifest do
       }
     ]
   end
+
+  it "errors if a release is called which isn't defined in the manifest releases list" do
+    unfindable_release = double(name: "wrong_name", version: 0)
+
+    expect do
+        manifest.use_release(unfindable_release)
+    end.to raise_error /#{unfindable_release.name} can not be found in manifest releases/
+  end
 end


### PR DESCRIPTION
If a release is called which is not defined in a manifest's releases
list it errors. Changed error message from "undefined method `store' for
nil:NilClass" to "RELEASE_NAME can not be found in manifest releases".

This resolves #18 at least the releases problem but does not address the stemcell issue