### PR TITLE
Enable the use of a runtime path for the CA cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ When using BOSH with [UAA authentication](https://bosh.io/docs/director-users-ua
 * `client_id`: *Required.* The UAA client ID for the BOSH director.
 * `client_secret`: *Required.* The UAA client secret for the BOSH director.
 
-* `ca_cert`: *Optional.* Path to CA certificate used to validate SSL connections to Director and UAA.
+* `ca_cert`: *Optional.* Contents of CA certificate used to validate SSL connections
+  to Director and UAA.
+* `ca_cert_file` *Optional.* Path to a file containing the CA certificate used to
+  validate SSL connections to Director and UAA. This allows you to determine the
+  CA certificate at runtime, e.g., by acquiring the certificate using the
+  [S3 resource](https://github.com/concourse/pool-resource).
+
+  If both `ca_cert_file` and `ca_cert` are specified, `ca_cert_file` takes
+  precedence.
 
 ### Example
 

--- a/bin/bdr_check
+++ b/bin/bdr_check
@@ -7,7 +7,7 @@ require 'bosh_deployment_resource'
 request = JSON.parse(STDIN.read)
 
 source = request.fetch("source")
-target = source["target"] || ""
+target = source["ca_cert_file"] ? "" : source["target"] || ""
 
 auth = BoshDeploymentResource::Auth.parse(source)
 ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])

--- a/bin/bdr_in
+++ b/bin/bdr_in
@@ -11,7 +11,7 @@ source = request.fetch("source")
 auth = BoshDeploymentResource::Auth.parse(source)
 ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])
 
-target = source["target"] || request["version"]["target"] || ""
+target = source["ca_cert_file"] ? "" : source["target"] || ""
 
 bosh = BoshDeploymentResource::Bosh.new(
   target,

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -20,7 +20,15 @@ target =
   end
 
 auth = BoshDeploymentResource::Auth.parse(source)
-ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])
+
+ca_cert_file = source["ca_cert_file"]
+ca_cert_contents =
+  if ca_cert_file
+    File.read(File.expand_path(ca_cert_file, working_dir))
+  else
+    source["ca_cert"]
+  end
+ca_cert = BoshDeploymentResource::CaCert.new(ca_cert_contents)
 
 bosh = BoshDeploymentResource::Bosh.new(
   target,

--- a/lib/bosh_deployment_resource/out_command.rb
+++ b/lib/bosh_deployment_resource/out_command.rb
@@ -45,8 +45,7 @@ module BoshDeploymentResource
 
       response = {
         "version" => {
-          "manifest_sha1" => manifest.shasum,
-          "target" => bosh.target
+          "manifest_sha1" => manifest.shasum
         },
         "metadata" =>
           stemcells.map { |s| { "name" => "stemcell", "value" => "#{s.name} v#{s.version}" } } +

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -86,15 +86,14 @@ describe "Out Command" do
       end
     end
 
-    it "emits the version as the manifest_sha1 and target" do
+    it "emits the version as the manifest_sha1" do
       in_dir do |working_dir|
         add_default_artefacts working_dir
 
         command.run(working_dir, request)
 
         expect(JSON.parse(response.string)["version"]).to eq({
-          "manifest_sha1" => manifest.shasum,
-          "target" => "bosh-target",
+          "manifest_sha1" => manifest.shasum
         })
       end
     end


### PR DESCRIPTION
Adds in the ability to specify a runtime path for the CA cert used. This is helpful if you store the cert elsewhere, and want to download it as part of the pipeline instead of defining it for every pipeline that may make use of the same BOSH instance.