### PR TITLE
Corrected ca_cert readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When using BOSH with [UAA authentication](https://bosh.io/docs/director-users-ua
 * `client_id`: *Required.* The UAA client ID for the BOSH director.
 * `client_secret`: *Required.* The UAA client secret for the BOSH director.
 
-* `ca_cert`: *Optional.* Path to CA certificate used to validate SSL connections to Director and UAA.
+* `ca_cert`: *Optional.* CA certificate used to validate SSL connections to Director and UAA.
 
 ### Example
 


### PR DESCRIPTION
The ca_cert field expects[1][2] the certificate contents not the certificate path.  

[1] https://github.com/concourse/bosh-deployment-resource/blob/master/bin/bdr_in#L12
[2] https://github.com/concourse/bosh-deployment-resource/blob/master/lib/bosh_deployment_resource/ca_cert.rb#L3:L5