### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM concourse/buildroot:ruby
 ADD gems /tmp/gems
 
 RUN gem install /tmp/gems/*.gem --no-document && \
-    gem install bosh_cli -v 1.3202.0 --no-document
+    gem install bosh_cli -v 1.3262.4.0 --no-document
 
 ADD . /tmp/resource-gem
 


### PR DESCRIPTION
Use newer version of bosh_cli gem.
Old version does not work well with CA certificates for domain names (and not IPs)