### PR TITLE
ignore header in release tarball

### DIFF
--- a/lib/bosh_deployment_resource/bosh_release.rb
+++ b/lib/bosh_deployment_resource/bosh_release.rb
@@ -29,7 +29,7 @@ module BoshDeploymentResource
 
       Archive::Tar::Minitar::Reader.open(tgz) do |reader|
         reader.each_entry do |entry|
-          next unless File.basename(entry.full_name) == "release.MF"
+          next unless File.basename(entry.full_name) == "release.MF" && entry.full_name.match('PaxHeader/release.MF').nil?
 
           return entry.read
         end


### PR DESCRIPTION
we find some tgz tarball has a header for each file. this fix ignores 'PaxHeader' files. more info about the Paxheader can be found in http://stackoverflow.com/questions/34688392/paxheaders-in-tarball