### PR TITLE
adds director_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ the UUID returned by the targeted director.
 
 * `cleanup`: *Optional* An boolean that specifies if a bosh cleanup should be
   run before deployment. Defaults to false.
+
 * `no_redact`: *Optional* Removes redacted from Bosh output. Defaults to false.
+
 * `target_file`: *Optional.* Path to a file containing a BOSH director address.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool
@@ -82,10 +84,11 @@ the UUID returned by the targeted director.
   password: some-password
 ```
 
-  If both `target_file` and `target` are specified, `target_file` takes
-  precedence.
+#### Precedence of Bosh Target
 
-  If both `target_file` and  `director_file` are specified, then `director_file`
-  takes precedence. If the `director_file` contains a username or password it
-  will override anything that has been specified in source.
+If `director_file` is specified, then it takes precedence when determing
+the bosh target. If the `director_file` contains a username or password it
+will override anything that has been specified in source.
 
+If `director_file` is not specified, but `target_file` and `target` are
+specified, `target_file` takes precedence.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and then deploy them.
 
 * `deployment`: *Required.* The name of the deployment.
 * `target`: *Optional.* The address of the BOSH director which will be used for
-  the deployment. If omitted, `target_file` must be specified via `out`
+  the deployment. If omitted, `target_file` or `director_file` must be specified via `out`
   parameters, as documented below.
 
 When using BOSH with default authentication:
@@ -73,6 +73,19 @@ the UUID returned by the targeted director.
   This allows the target to be determined at runtime, e.g. by acquiring a BOSH
   lite instance using the [Pool
   resource](https://github.com/concourse/pool-resource).
+* `director_file`: *Optional.* Path to a yaml file contain that looks as such:
+
+```yaml
+  ---
+  target: http://example.com/bosh:255555
+  username: some-username
+  password: some-password
+```
 
   If both `target_file` and `target` are specified, `target_file` takes
   precedence.
+
+  If both `target_file` and  `director_file` are specified, then `director_file`
+  takes precedence. If the `director_file` contains a username or password it
+  will override anything that has been specified in source.
+

--- a/bin/bdr_in
+++ b/bin/bdr_in
@@ -8,6 +8,10 @@ working_dir = ARGV[0]
 request = JSON.parse(STDIN.read)
 
 source = request.fetch("source")
+
+source["username"] ||= request["version"]["username"] || ""
+source["password"] ||= request["version"]["password"] || ""
+
 auth = BoshDeploymentResource::Auth.parse(source)
 ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])
 

--- a/bin/bdr_in
+++ b/bin/bdr_in
@@ -11,14 +11,13 @@ source = request.fetch("source")
 
 source["username"] ||= request["version"]["username"] || ""
 source["password"] ||= request["version"]["password"] || ""
+source["target"] ||= request["version"]["target"] || ""
 
 auth = BoshDeploymentResource::Auth.parse(source)
 ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])
 
-target = source["target"] || request["version"]["target"] || ""
-
 bosh = BoshDeploymentResource::Bosh.new(
-  target,
+  source["target"],
   ca_cert,
   auth
 )

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -11,19 +11,24 @@ source = request.fetch("source")
 params = request.fetch("params")
 
 target_file = params["target_file"]
+if target_file
+  source["target"] = File.read(File.expand_path(target_file, working_dir)).strip
+  STDOUT.puts "target_file is deprecated in favor of director_file, you've been warned"
+end
 
-target =
-  if target_file
-    File.read(File.expand_path(target_file, working_dir)).strip
-  else
-    source.fetch("target")
-  end
+director_file = params["director_file"]
+if director_file
+  director = YAML.load(File.read(File.expand_path(director_file, working_dir)))
+  source["target"] = director["target"]
+  source["username"] = director["username"] || source["username"]
+  source["password"] = director["password"] || source["password"]
+end
 
 auth = BoshDeploymentResource::Auth.parse(source)
 ca_cert = BoshDeploymentResource::CaCert.new(source["ca_cert"])
 
 bosh = BoshDeploymentResource::Bosh.new(
-  target,
+  source.fetch("target"),
   ca_cert,
   auth
 )

--- a/lib/bosh_deployment_resource/auth.rb
+++ b/lib/bosh_deployment_resource/auth.rb
@@ -27,6 +27,8 @@ module BoshDeploymentResource
       new(options.fetch("username"), options.fetch("password"))
     end
 
+    attr_reader :username, :password
+
     def initialize(username, password)
       @username = username
       @password = password

--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -12,7 +12,6 @@ module BoshDeploymentResource
       @command_runner = command_runner
     end
 
-
     def upload_stemcell(path)
       bosh("upload stemcell #{path} --skip-if-exists")
     end
@@ -35,6 +34,14 @@ module BoshDeploymentResource
 
     def cleanup
       bosh("cleanup")
+    end
+
+    def username
+      @auth.username
+    end
+
+    def password
+      @auth.password
     end
 
     def director_uuid

--- a/lib/bosh_deployment_resource/out_command.rb
+++ b/lib/bosh_deployment_resource/out_command.rb
@@ -46,7 +46,9 @@ module BoshDeploymentResource
       response = {
         "version" => {
           "manifest_sha1" => manifest.shasum,
-          "target" => bosh.target
+          "target" => bosh.target,
+          "username" => bosh.username,
+          "password" => bosh.password
         },
         "metadata" =>
           stemcells.map { |s| { "name" => "stemcell", "value" => "#{s.name} v#{s.version}" } } +


### PR DESCRIPTION
As more people more toward `bbl` and having auto-generated username / password combos for directors (more secure) we wanted to make a change to how the file format worked.

- `target_file` is deprecated but still available
- `director_file` is the true way
- source specification of username / password while ONLY specifying a target in your `director_file` still works. This should maintain workflow backward compatibility.