### PR TITLE
Don't modify bosh manifest with blobs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ the UUID returned by the targeted director.
 * `releases`: *Required.* An array of globs that should point to where the
   releases used in the deployment can be found.
 
+* `no_version_update`: *Optional* This flag avoids that the manifest is modified to use the stemcell or bosh releases provided as blobs.  Defaults set to false.
+
 * `cleanup`: *Optional* An boolean that specifies if a bosh cleanup should be
   run before deployment. Defaults to false.
 

--- a/lib/bosh_deployment_resource/out_command.rb
+++ b/lib/bosh_deployment_resource/out_command.rb
@@ -14,6 +14,8 @@ module BoshDeploymentResource
 
       bosh.cleanup if request.fetch("params")["cleanup"].equal? true
 
+      no_version_update = request.fetch("params")["no_version_update"] .equal? true
+
       stemcells = []
       releases = []
 
@@ -26,14 +28,13 @@ module BoshDeploymentResource
       manifest.validate_stemcells(stemcells)
 
       stemcells.each do |stemcell|
-        manifest.use_stemcell(stemcell)
+        manifest.use_stemcell(stemcell) unless no_version_update
         bosh.upload_stemcell(stemcell.path)
       end
 
       find_releases(working_dir, request).each do |release_path|
         release = BoshRelease.new(release_path)
-        manifest.use_release(release)
-
+        manifest.use_release(release) unless no_version_update
         bosh.upload_release(release_path)
 
         releases << release
@@ -72,6 +73,12 @@ module BoshDeploymentResource
       when nil, true, false
       else
         raise "given cleanup value must be a boolean"
+      end
+
+      case request.fetch("params")["no_version_update"]
+      when nil, true, false
+      else
+        raise "given no_version_update value must be a boolean"
       end
 
       ["manifest", "stemcells", "releases"].each do |field|

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -193,6 +193,30 @@ describe "Out Command" do
         command.run(working_dir, request)
       end
     end
+
+    it "does update a bosh manifest with stemcell and releases when the no_version_update parameter is NOT passed" do
+      in_dir do |working_dir|
+        add_default_artefacts working_dir
+
+        expect(manifest).to receive(:use_stemcell)
+        expect(manifest).to receive(:use_release)
+
+        command.run(working_dir, request)
+      end
+    end
+
+    it "does NOT update a bosh manifest with stemcell and releases when the no_version_update parameter set to true" do
+      request.fetch("params").store("no_version_update", true)
+
+      in_dir do |working_dir|
+        add_default_artefacts working_dir
+
+        expect(manifest).to_not receive(:use_stemcell)
+        expect(manifest).to_not receive(:use_release)
+
+        command.run(working_dir, request)
+      end
+    end
   end
 
   context "with invalid inputs" do
@@ -288,6 +312,27 @@ describe "Out Command" do
             }
           })
         end.to raise_error /given cleanup value must be a boolean/
+      end
+    end
+
+    it "errors if the no_version_update paramater is NOT a boolean value" do
+      in_dir do |working_dir|
+        expect do
+          command.run(working_dir, {
+            "source" => {
+              "target" => "http://bosh.example.com",
+              "username" => "bosh-username",
+              "password" => "bosh-password",
+              "deployment" => "bosh-deployment",
+            },
+            "params" => {
+              "manifest" => "deployment.yml",
+              "stemcells" => [],
+              "releases" => [],
+              "no_version_update" => 1
+            }
+          })
+        end.to raise_error /given no_version_update value must be a boolean/
       end
     end
 


### PR DESCRIPTION
hi @vito 

By default, this resource is modifying the bosh manifest and add the new versions found in the blobs. 

In many occasion we don't want to do that from our site, just let the bosh deployment resource upload the blobs for us but still let us specify the version we want to deploy in the bosh manifest. 

Additionally, I have added a couple of tests for the option `no_redact` that were missing. 