### PR TITLE
Update bosh_cli gem to latest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM concourse/buildroot:ruby
 ADD gems /tmp/gems
 
 RUN gem install /tmp/gems/*.gem --no-document && \
-    gem install bosh_cli -v 1.3262.4.0 --no-document
+    gem install bosh_cli -v 1.3262.26.0 --no-document
 
 ADD . /tmp/resource-gem
 


### PR DESCRIPTION
Release teams are starting to use `sha2`.  Uploading such releases requires a newer version of the `bosh_cli` gem.