### PR TITLE
Add bosh_cli gem to gemspec

### DIFF
--- a/bosh_deployment_resource.gemspec
+++ b/bosh_deployment_resource.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "bosh_cli"
   spec.add_dependency "minitar"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Hi, from concourseci.slack.com conversation:
```
infrared [10:55 PM] 
Looks like `bosh_cli` gem disappear after switching to alpine image. `gem install bosh_cli` line was removed from dockerfile and not added to gemfile. maybe i missed smth :thinking_face:
https://github.com/concourse/bosh-deployment-resource/commit/289d7e33babfb8800ea1e9d02cf4c11eec97e15c
https://github.com/concourse/concourse/commit/78597dffaf8809329f531563a119d40cdaa4bfff (edited)

jtarchie [11:05 PM] 
@infrared, no it looks like it was meant to be in the gemspec, but isn’t — https://github.com/concourse/bosh-deployment-resource/blob/master/bosh_deployment_resource.gemspec#L17
 
 [11:05] 
It is funny that the test pass, though.

[11:06] 
We can fix this.

[11:07] 
Though this is deprecated resource.
```
Thanks!